### PR TITLE
feat(sparse-tools): add endpoint for syncing metafile

### DIFF
--- a/cli/ssync/main.go
+++ b/cli/ssync/main.go
@@ -2,6 +2,8 @@ package ssync
 
 import (
 	"flag"
+	"net/http"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -42,7 +44,9 @@ func Main() {
 
 		ops := &rest.SyncFileStub{}
 		err := rest.Server(*port, dstPath, ops)
-		if err != nil {
+		if err == http.ErrServerClosed {
+			log.Info("Ssync server: exit code 0")
+		} else if err != nil {
 			log.Fatalf("Ssync server failed, err: %s", err)
 		}
 	} else {
@@ -59,4 +63,5 @@ func Main() {
 		}
 		log.Info("Ssync client: exit code 0")
 	}
+	os.Exit(0)
 }

--- a/sparse/client.go
+++ b/sparse/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -27,6 +28,16 @@ type syncClient struct {
 }
 
 const connectionRetries = 5
+
+func unmarshalFile(file string, obj interface{}) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return json.NewDecoder(f).Decode(obj)
+}
 
 // SyncFile synchronizes local file to remote host
 func SyncFile(localPath string, remote string, timeout int) error {
@@ -53,14 +64,24 @@ func SyncFile(localPath string, remote string, timeout int) error {
 
 	client := &syncClient{remote, timeout, localPath, fileSize, fileIo}
 
-	defer client.closeServer() // kill the server no matter success or not, best effort
+	// kill the server no matter success or not, best effort
+	defer client.closeServer()
 
-	err = client.syncFileContent(fileIo, fileSize)
+	if strings.HasSuffix(localPath, ".meta") {
+		data := make(map[string]interface{})
+		err = unmarshalFile(localPath, &data)
+		if err != nil {
+			log.Errorf("Failed to unmarshal meta data from file, err: %v", err)
+			return err
+		}
+		err = client.sendMetaData(data)
+	} else {
+		err = client.syncFileContent(fileIo, fileSize)
+	}
 	if err != nil {
 		log.Errorf("syncFileContent failed: %s", err)
 		return err
 	}
-
 	return err
 }
 
@@ -127,6 +148,32 @@ func (client *syncClient) syncFileContent(file FileIoProcessor, fileSize int64) 
 	return nil
 }
 
+func (client *syncClient) sendRequest(action string, data interface{}) error {
+	httpClient := &http.Client{Timeout: time.Duration(httpClientTimeout * time.Second)}
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	bodyType := "application/json"
+	url := fmt.Sprintf("http://%s/v1-ssync/%s", client.remote, action)
+
+	log.Debugf("POST %s, data: %v", url, string(b))
+
+	httpResp, err := httpClient.Post(url, bodyType, bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode >= 300 {
+		content, _ := ioutil.ReadAll(httpResp.Body)
+		return fmt.Errorf("Bad response: %d %s: %s", httpResp.StatusCode, httpResp.Status, content)
+	}
+	return nil
+}
+
 func (client *syncClient) sendHTTPRequest(method string, action string, interval Interval, data []byte) (*http.Response, error) {
 	httpClient := &http.Client{Timeout: time.Duration(httpClientTimeout * time.Second)}
 
@@ -180,6 +227,30 @@ func (client *syncClient) openServer() error {
 		return fmt.Errorf("resp.StatusCode(%d) != http.StatusOK", resp.StatusCode)
 	}
 	resp.Body.Close()
+
+	return nil
+}
+
+func (client *syncClient) sendMetaData(data interface{}) error {
+	var err error
+
+	timeStart := time.Now()
+	timeStop := timeStart.Add(time.Duration(client.timeout) * time.Second)
+	for timeNow := timeStart; timeNow.Before(timeStop); timeNow = time.Now() {
+		err = client.sendRequest("writeMetaData", data)
+		if err == nil {
+			break
+		}
+		log.Warnf("Failed to send request to %s, Retrying...", client.remote)
+		if timeNow != timeStart {
+			// only sleep after the second attempt to speedup tests
+			time.Sleep(1 * time.Second)
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("send failed, err: %s", err)
+	}
 
 	return nil
 }

--- a/sparse/rest/handlers.go
+++ b/sparse/rest/handlers.go
@@ -48,6 +48,49 @@ func (server *SyncServer) getQueryInterval(request *http.Request) (sparse.Interv
 	return sparse.Interval{Begin: begin, End: end}, err
 }
 
+func (server *SyncServer) writeMetaFile(writer http.ResponseWriter, request *http.Request) {
+	err := server.encodeToFile(request)
+	if err != nil {
+		log.Errorf("encode to file failed, err: %s", err)
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Debugf("Written to metafile successfully")
+	writer.WriteHeader(http.StatusOK)
+}
+
+func (server *SyncServer) encodeToFile(request *http.Request) error {
+	data, err := ioutil.ReadAll(request.Body)
+	if err != nil {
+		return fmt.Errorf("Failed to read request, err: %v", err)
+	}
+
+	f, err := os.Create(server.filePath + ".tmp")
+	if err != nil {
+		log.Errorf("failed to create temp file: %s while encoding the data to file", server.filePath)
+		return err
+	}
+	defer f.Close()
+
+	var jsonData map[string]interface{}
+	if err := json.Unmarshal(data, &jsonData); err != nil {
+		log.Errorf("failed to unmarshal the data: %v to json: %v", string(data), jsonData)
+		return err
+	}
+
+	if err := json.NewEncoder(f).Encode(&jsonData); err != nil {
+		log.Errorf("failed to encode the data: %v to file: %s", string(data), f.Name())
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		log.Errorf("failed to close file after encoding to file: %s", f.Name())
+		return err
+	}
+
+	return os.Rename(server.filePath+".tmp", server.filePath)
+}
+
 func (server *SyncServer) open(writer http.ResponseWriter, request *http.Request) {
 	err := server.doOpen(request)
 	if err != nil {
@@ -95,7 +138,9 @@ func (server *SyncServer) close(writer http.ResponseWriter, request *http.Reques
 		f.Flush()
 	}
 
-	server.fileIo.Close()
+	if server.fileIo != nil {
+		server.fileIo.Close()
+	}
 	log.Infof("Closing ssync server")
 
 	server.srv.Close()

--- a/sparse/rest/router.go
+++ b/sparse/rest/router.go
@@ -11,6 +11,7 @@ func NewRouter(server *SyncServer) *mux.Router {
 	// Application
 	router.HandleFunc("/v1-ssync/getChecksum", server.getChecksum).Methods("GET")
 	router.HandleFunc("/v1-ssync/open", server.open).Methods("GET")
+	router.HandleFunc("/v1-ssync/writeMetaData", server.writeMetaFile).Methods("POST")
 	router.HandleFunc("/v1-ssync/close", server.close).Methods("POST")
 	router.HandleFunc("/v1-ssync/sendHole", server.sendHole).Methods("POST")
 	router.HandleFunc("/v1-ssync/writeData", server.writeData).Methods("POST")


### PR DESCRIPTION
This commit adds an endpoint `writeMetaFile` to sync the contents
of metafile by writing the data into temp file and then renaming it
to  make contents of file consistent across crash.
Fixes: openebs/openebs#2950
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>