### PR TITLE
fix(sparse-tools): do retry in case of http error

### DIFF
--- a/cli/ssync/main.go
+++ b/cli/ssync/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -26,9 +27,11 @@ func Main() {
 	daemon := flag.Bool("daemon", false, "daemon mode (run on remote host)")
 	port := flag.String("port", "5000", "optional daemon port")
 	timeout := flag.Int("timeout", 120, "optional daemon/client timeout (seconds)")
+	httpTimeout := flag.Int("httpTimeout", 30, "optional http request timeout (seconds)")
 	host := flag.String("host", "", "remote host of <DstFile> (requires running daemon)")
 
 	flag.Parse()
+	sparse.HTTPClientTimeout = time.Duration(*httpTimeout) * time.Second
 
 	if *verbose {
 		log.SetLevel(log.DebugLevel)

--- a/sparse/client.go
+++ b/sparse/client.go
@@ -15,8 +15,11 @@ import (
 )
 
 const (
-	httpClientTimeout = 5
-	numBlocksInBatch  = 32
+	numBlocksInBatch = 32
+)
+
+var (
+	HTTPClientTimeout time.Duration = 30
 )
 
 type syncClient struct {
@@ -149,7 +152,7 @@ func (client *syncClient) syncFileContent(file FileIoProcessor, fileSize int64) 
 }
 
 func (client *syncClient) sendRequest(action string, data interface{}) error {
-	httpClient := &http.Client{Timeout: time.Duration(httpClientTimeout * time.Second)}
+	httpClient := &http.Client{Timeout: HTTPClientTimeout}
 
 	b, err := json.Marshal(data)
 	if err != nil {
@@ -175,7 +178,7 @@ func (client *syncClient) sendRequest(action string, data interface{}) error {
 }
 
 func (client *syncClient) sendHTTPRequest(method string, action string, interval Interval, data []byte) (*http.Response, error) {
-	httpClient := &http.Client{Timeout: time.Duration(httpClientTimeout * time.Second)}
+	httpClient := &http.Client{Timeout: HTTPClientTimeout}
 
 	url := fmt.Sprintf("http://%s/v1-ssync/%s", client.remote, action)
 


### PR DESCRIPTION
This commit fix an issue where degarded replicas were getting
killed due to client timeout exceeded error in sync client
while getting checksum from sync server. Now the request will
be retried on error and http timeout will be incremented.

Fixes: https://github.com/openebs/openebs/issues/2978

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>