### PR TITLE
fix(metaFiles): open MetaFiles with O_SYNC flag

### DIFF
--- a/sparse/rest/handlers.go
+++ b/sparse/rest/handlers.go
@@ -65,7 +65,9 @@ func (server *SyncServer) encodeToFile(request *http.Request) error {
 		return fmt.Errorf("Failed to read request, err: %v", err)
 	}
 
-	f, err := os.Create(server.filePath + ".tmp")
+	// Metadata files need to be opened in O_SYNC mode so that it is immediately synced to disk,
+	// if the kernel crashes, the data in these files might be lost.
+	f, err := os.OpenFile(server.filePath+".tmp", os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, 0666)
 	if err != nil {
 		log.Errorf("failed to create temp file: %s while encoding the data to file", server.filePath)
 		return err


### PR DESCRIPTION
This PR along with https://github.com/openebs/jiva/pull/337 fixes the following issue: https://github.com/openebs/jiva/issues/338
On crashing the kernel simultaneously at all the nodes, one of the replica fails to come up and enters into CrashLoopBackOff state with this error:
 ```failed to read disk data, error while unmarshalling file: volume-snap-1db04a94-0aa0-4404-bbbb-3641392d587f.img.meta```

This issue occured because metadata files are not synced to disk immediately. It is not seen with data files as those are opened with O_DIRECT flag.

As a fix, Metadata files are now being opened with O_SYNC flag.

Signed-off-by: Payes Anand <payes.anand@mayadata.io>